### PR TITLE
Add README.md to templating config.

### DIFF
--- a/templates/_templating_config.json
+++ b/templates/_templating_config.json
@@ -1,4 +1,5 @@
 {
+  "README.md": {},
   "_templating_config.json": {},
   "_templating_scripting.py": {},
   ".pre-commit-config.yaml": {


### PR DESCRIPTION
Since (IIUC) the `align_dirs` action, `check_dirs` step --> script `check_dir` command, which is currently failing,
because this requires that all files in the `templates` folder must appear in the config JSON.